### PR TITLE
 Adaption of the import of the XML structure to new AIT firmware sinc…

### DIFF
--- a/pkg/luxtronik/luxtronik.go
+++ b/pkg/luxtronik/luxtronik.go
@@ -70,6 +70,8 @@ func Connect(ip string, filters Filters) *Luxtronik {
 		if err != nil {
 			panic(err)
 		}
+		// change nested structure to depth of one level
+		updatedVals = flattenNestedStructure(updatedVals)
 
 		items := []item{}
 		for _, c := range updatedVals.Categories {


### PR DESCRIPTION


Since firmware V3.88.0 ait has changed the XML structure for energy values.

Before we had only a depth of one level in the XML. But with this firmware they changed it to a nested XML structure.

Example of the important part:

```
<Content>
    <item id='0x7b108c'>
        <name>Betriebsstunden</name>
        <item id='0x7bc36c'>
            <name>Betriebstund. VD1</name>
            <value>8024h</value>
        </item>
        <item id='0x7bc3b4'>
            <name>Impulse Verdichter 1</name>
            <value>8098</value>
        </item>
        <item id='0x7bc3fc'>
            <name>Laufzeit Ø VD1</name>
            <value>00:59</value>
        </item>
        <item id='0x7bc51c'>
            <name>Betriebstunden ZWE1</name>
            <value>30h</value>
        </item>
        <item id='0x7bc5f4'>
            <name>Betriebstunden WP</name>
            <value>8024h</value>
        </item>
        <item id='0x7bc63c'>
            <name>Betriebstunden Heiz.</name>
            <value>7235h</value>
        </item>
        <item id='0x7bc684'>
            <name>Betriebstunden WW</name>
            <value>415h</value>
        </item>
        <item id='0x7bc6cc'>
            <name>Betriebstunden Kuehl</name>
            <value>373h</value>
        </item>
        <name>Betriebsstunden</name>
    </item>
    <item id='0x7b9914'>
        <name>Energiemonitor</name>
        <item id='0x7c0b9c'>
            <name>Wärmemenge</name>
            <item id='0x7bec9c'>
                <name>Heizung</name>
                <value>34427.4 kWh</value>
            </item>
            <item id='0x7bf3dc'>
                <name>Warmwasser</name>
                <value>1988.6 kWh</value>
            </item>
            <item id='0x7bf464'>
                <name>Kühlung</name>
                <value>26.1 kWh</value>
            </item>
            <item id='0x7bf21c'>
                <name>Gesamt</name>
                <value>36442.1 kWh</value>
            </item>
            <name>Wärmemenge</name>
        </item>
        <item id='0x7c139c'>
            <name>Eingesetzte Energie</name>
            <item id='0x7bf35c'>
                <name>Heizung</name>
                <value>174.7 kWh</value>
            </item>
            <item id='0x7bf95c'>
                <name>Warmwasser</name>
                <value>0.0 kWh</value>
            </item>
            <item id='0x7c009c'>
                <name>Kühlung</name>
                <value>4.0 kWh</value>
            </item>
            <item id='0x7c00e4'>
                <name>Gesamt</name>
                <value>178.7 kWh</value>
            </item>
            <name>Eingesetzte Energie</name>
        </item>
        <name>Energiemonitor</name>
    </item>
</Content>
```

This change moves the data from the nested level to the first level with concatenated names of both levels.
